### PR TITLE
Add possibility to color reads by sam tag

### DIFF
--- a/public/viper/pages/inspector/inspector.html
+++ b/public/viper/pages/inspector/inspector.html
@@ -98,6 +98,17 @@
             <option value="UNEXPECTED_PAIR">insert size and pair orientation</option>
             <option value="FIRST_OF_PAIR_STRAND">first-of-pair strand</option>
             <option value="READ_GROUP">read group</option>
+            <option value="TAG">tag</option>
+          </select>
+        </div>
+        <div class="form-group" ng-class="{ 'has-error': inspectorCtrl.configuration['SAM.COLOR_BY_TAG'] == null}">
+          <label>Color reads by tag:</label>
+          <input
+            type="text"
+            class="form-control"
+            ng-pattern="/^[a-zA-Z]{2}$/"
+            ng-model="inspectorCtrl.configuration['SAM.COLOR_BY_TAG']"
+            ng-change="inspectorCtrl.changeIGVSetting('SAM.COLOR_BY_TAG')">
           </select>
         </div>
         <div class="form-group">


### PR DESCRIPTION
I often annotate custom evidence using sam tags, and being able to highlight
reads with custom tags is a helpful functionality in IGV. I hope you can include
something like this in a future version of VIPER.